### PR TITLE
Fronius Solar API V1 meter config templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Additional devices can be configured using the `generic` device type and related
 - [E3DC (Battery)](#meter-e3dc-battery)
 - [E3DC (Grid Meter)](#meter-e3dc-grid-meter)
 - [E3DC (PV Meter)](#meter-e3dc-pv-meter)
+- [Fronius Solar API V1 (grid S0 meter/ HTTP)](#meter-fronius-solar-api-v1-grid-s0-meter-http)
+- [Fronius Solar API V1 (PV meter/ HTTP)](#meter-fronius-solar-api-v1-pv-meter-http)
 - [Generisch (MQTT)](#meter-generisch-mqtt)
 - [Generisch (Script)](#meter-generisch-script)
 - [Kostal Inverter (Grid Meter)](#meter-kostal-inverter-grid-meter)
@@ -140,6 +142,28 @@ Additional devices can be configured using the `generic` device type and related
       address: 40067 # (40068 - 1) "Photovoltaikleistung in Watt"
       type: holding
       decode: int32s
+```
+
+<a id="meter-fronius-solar-api-v1-grid-s0-meter-http"></a>
+#### Fronius Solar API V1 (grid S0 meter/ HTTP)
+
+```yaml
+- type: default
+  power: # Grid power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
+    type: http # use http plugin for grid power (P_Grid)
+    uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+    jq: if .Body.Data.Site.P_Grid == null then 0 else .Body.Data.Site.P_Grid end # parse GetPowerFlowRealtimeData P_Grid response
+```
+
+<a id="meter-fronius-solar-api-v1-pv-meter-http"></a>
+#### Fronius Solar API V1 (PV meter/ HTTP)
+
+```yaml
+- type: default
+  power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_PV
+    type: http # use http plugin for pv power (P_PV)
+    uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+    jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end # parse GetPowerFlowRealtimeData P_PV response
 ```
 
 <a id="meter-generisch-mqtt"></a>

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Additional devices can be configured using the `generic` device type and related
 - [E3DC (Battery)](#meter-e3dc-battery)
 - [E3DC (Grid Meter)](#meter-e3dc-grid-meter)
 - [E3DC (PV Meter)](#meter-e3dc-pv-meter)
-- [Fronius Solar API V1 (grid S0 meter/ HTTP)](#meter-fronius-solar-api-v1-grid-s0-meter-http)
+- [Fronius Solar API V1 (Grid S0 meter/ HTTP)](#meter-fronius-solar-api-v1-grid-s0-meter-http)
 - [Fronius Solar API V1 (PV meter/ HTTP)](#meter-fronius-solar-api-v1-pv-meter-http)
 - [Generisch (MQTT)](#meter-generisch-mqtt)
 - [Generisch (Script)](#meter-generisch-script)
@@ -145,7 +145,7 @@ Additional devices can be configured using the `generic` device type and related
 ```
 
 <a id="meter-fronius-solar-api-v1-grid-s0-meter-http"></a>
-#### Fronius Solar API V1 (grid S0 meter/ HTTP)
+#### Fronius Solar API V1 (Grid S0 meter/ HTTP)
 
 ```yaml
 - type: default

--- a/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
@@ -1,0 +1,19 @@
+package templates 
+
+import (
+	"github.com/andig/evcc-config/registry"
+)
+
+func init() {
+	template := registry.Template{
+		Class:  "meter",
+		Type:   "default",
+		Name:   "Fronius Solar API V1 (grid S0 meter/ HTTP)",
+		Sample: `power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
+        type: http # use http plugin for grid power (P_Grid)
+        uri: http://192.168.178.18/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+        jq: if .Body.Data.Site.P_Grid == null then 0 else .Body.Data.Site.P_Grid end # parse GetPowerFlowRealtimeData P_Grid response`,
+	}
+
+	registry.Add(template)
+}

--- a/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
@@ -9,10 +9,10 @@ func init() {
 		Class:  "meter",
 		Type:   "default",
 		Name:   "Fronius Solar API V1 (grid S0 meter/ HTTP)",
-		Sample: `power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
-        type: http # use http plugin for grid power (P_Grid)
-        uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
-        jq: if .Body.Data.Site.P_Grid == null then 0 else .Body.Data.Site.P_Grid end # parse GetPowerFlowRealtimeData P_Grid response`,
+		Sample: `power: # Grid power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
+  type: http # use http plugin for grid power (P_Grid)
+  uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+  jq: if .Body.Data.Site.P_Grid == null then 0 else .Body.Data.Site.P_Grid end # parse GetPowerFlowRealtimeData P_Grid response`,
 	}
 
 	registry.Add(template)

--- a/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
@@ -8,7 +8,7 @@ func init() {
 	template := registry.Template{
 		Class:  "meter",
 		Type:   "default",
-		Name:   "Fronius Solar API V1 (grid S0 meter/ HTTP)",
+		Name:   "Fronius Solar API V1 (Grid S0 meter/ HTTP)",
 		Sample: `power: # Grid power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
   type: http # use http plugin for grid power (P_Grid)
   uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi

--- a/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-grid-S0.go
@@ -11,7 +11,7 @@ func init() {
 		Name:   "Fronius Solar API V1 (grid S0 meter/ HTTP)",
 		Sample: `power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
         type: http # use http plugin for grid power (P_Grid)
-        uri: http://192.168.178.18/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+        uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
         jq: if .Body.Data.Site.P_Grid == null then 0 else .Body.Data.Site.P_Grid end # parse GetPowerFlowRealtimeData P_Grid response`,
 	}
 

--- a/templates/meter-default-http-fronius-solar-api-v1-pv.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-pv.go
@@ -11,7 +11,7 @@ func init() {
 		Name:   "Fronius Solar API V1 (PV meter/ HTTP)",
 		Sample: `power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_PV
         type: http # use http plugin for pv power (P_PV)
-        uri: http://192.168.178.18/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+        uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
         jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end # parse GetPowerFlowRealtimeData P_PV response`,
 	}
 

--- a/templates/meter-default-http-fronius-solar-api-v1-pv.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-pv.go
@@ -10,9 +10,9 @@ func init() {
 		Type:   "default",
 		Name:   "Fronius Solar API V1 (PV meter/ HTTP)",
 		Sample: `power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_PV
-        type: http # use http plugin for pv power (P_PV)
-        uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
-        jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end # parse GetPowerFlowRealtimeData P_PV response`,
+  type: http # use http plugin for pv power (P_PV)
+  uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+  jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end # parse GetPowerFlowRealtimeData P_PV response`,
 	}
 
 	registry.Add(template)

--- a/templates/meter-default-http-fronius-solar-api-v1-pv.go
+++ b/templates/meter-default-http-fronius-solar-api-v1-pv.go
@@ -1,0 +1,19 @@
+package templates 
+
+import (
+	"github.com/andig/evcc-config/registry"
+)
+
+func init() {
+	template := registry.Template{
+		Class:  "meter",
+		Type:   "default",
+		Name:   "Fronius Solar API V1 (PV meter/ HTTP)",
+		Sample: `power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_PV
+        type: http # use http plugin for pv power (P_PV)
+        uri: http://192.168.178.18/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+        jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end # parse GetPowerFlowRealtimeData P_PV response`,
+	}
+
+	registry.Add(template)
+}

--- a/yaml/meters/default-http-fronius-solar-api-v1-grid-S0.yaml
+++ b/yaml/meters/default-http-fronius-solar-api-v1-grid-S0.yaml
@@ -1,5 +1,5 @@
 type: default
-name: Fronius Solar API V1 (grid S0 meter/ HTTP)
+name: Fronius Solar API V1 (Grid S0 meter/ HTTP)
 sample: |
   power: # Grid power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
     type: http # use http plugin for grid power (P_Grid)

--- a/yaml/meters/default-http-fronius-solar-api-v1-grid-S0.yaml
+++ b/yaml/meters/default-http-fronius-solar-api-v1-grid-S0.yaml
@@ -1,0 +1,7 @@
+type: default
+name: Fronius Solar API V1 (grid S0 meter/ HTTP)
+sample: |
+  power: # Grid power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_Grid
+    type: http # use http plugin for grid power (P_Grid)
+    uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+    jq: if .Body.Data.Site.P_Grid == null then 0 else .Body.Data.Site.P_Grid end # parse GetPowerFlowRealtimeData P_Grid response

--- a/yaml/meters/default-http-fronius-solar-api-v1-pv.yaml
+++ b/yaml/meters/default-http-fronius-solar-api-v1-pv.yaml
@@ -1,0 +1,7 @@
+type: default
+name: Fronius Solar API V1 (PV meter/ HTTP)
+sample: |
+  power: # pv power reading Fronius Solar API V1 GetPowerFlowRealtimeData.P_PV
+    type: http # use http plugin for pv power (P_PV)
+    uri: http://192.0.2.2/solar_api/v1/GetPowerFlowRealtimeData.fcgi
+    jq: if .Body.Data.Site.P_PV == null then 0 else .Body.Data.Site.P_PV end # parse GetPowerFlowRealtimeData P_PV response


### PR DESCRIPTION
Hi,
ich habe mal für pv und grid für die Fronius Solar API V1 templates erstellt.
Für Privat-Anwender ist die Definition m.E. "intuitiver", als die Sunspec modbus Variante ... 

Die Templates arbeiten mit dem GetPowerFlowRealtimeData Request, der bei meinem Fronius Symo 6.0-3-M folgenden JSON Output generiert.    
In der Inverter Section werden die Werte pro Inverter DeviceId gelistet, danach erfolgen die Summen für die Gesamte "Site": 
````
{
   "Body" : {
      "Data" : {
         "Inverters" : {
            "1" : {
               "DT" : 110,
               "E_Day" : 945.9000244140625,
               "E_Total" : 45491900,
               "E_Year" : 89010,
               "P" : 873
            }
         },
         "Site" : {
            "E_Day" : 945.9000244140625,
            "E_Total" : 45491900,
            "E_Year" : 89010,
            "Meter_Location" : "load",
            "Mode" : "vague-meter",
            "P_Akku" : null,
            "P_Grid" : 1311.4659971373676,
            "P_Load" : -2184.4659971373676,
            "P_PV" : 873,
            "rel_Autonomy" : 39.964000407606363,
            "rel_SelfConsumption" : 100
         },
         "Version" : "12"
      }
   },
   "Head" : {
      "RequestArguments" : {},
      "Status" : {
         "Code" : 0,
         "Reason" : "",
         "UserMessage" : ""
      },
      "Timestamp" : "2021-01-29T12:04:35+01:00"
   }
}
````

Auf meinem Ubuntu 20.04 liefern die config templates folgenden meter test Output:
````
thierolm@tserver:~/evcc/git/evcc$ sudo ./evcc -c ~/evcc/evcc.yaml -l debug meter
[sudo] Passwort für thierolm:
[main  ] INFO 2021/01/29 12:08:43 evcc 0.41 (a0cafef)
[main  ] INFO 2021/01/29 12:08:43 using config file /home/thierolm/evcc/evcc.yaml
grid
----
Power: 1644W

pv
--
Power: 761W

````



API Dokus als PDF anbei:
[Fronius_Wechselrichter_Solar_API_V1.pdf](https://github.com/andig/evcc-config/files/5889473/Fronius_Wechselrichter_Solar_API_V1.pdf)
[Fronius_Wechselrichter_Modbus_TCP_RTU.pdf](https://github.com/andig/evcc-config/files/5889481/Fronius_Wechselrichter_Modbus_TCP_RTU.pdf)

