### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,6 @@ Additional devices can be configured using the `generic` device type and related
     type: http # use http plugin
     uri: http://192.0.2.2:8080/api/v1/status
     jq: .Pac_total_W
-    scale: -1 # reverse direction
   soc:
     type: http
     uri: http://192.0.2.2:8080/api/v1/status

--- a/templates/meter-default-http-sonnen-battery.go
+++ b/templates/meter-default-http-sonnen-battery.go
@@ -13,7 +13,6 @@ func init() {
   type: http # use http plugin
   uri: http://192.0.2.2:8080/api/v1/status
   jq: .Pac_total_W
-  scale: -1 # reverse direction
 soc:
   type: http
   uri: http://192.0.2.2:8080/api/v1/status

--- a/yaml/meters/default-http-sonnen-battery.yaml
+++ b/yaml/meters/default-http-sonnen-battery.yaml
@@ -5,7 +5,6 @@ sample: |
     type: http # use http plugin
     uri: http://192.0.2.2:8080/api/v1/status
     jq: .Pac_total_W
-    scale: -1 # reverse direction
   soc:
     type: http
     uri: http://192.0.2.2:8080/api/v1/status


### PR DESCRIPTION
Removed reverse direction from Sonnenbatterie Eco/10 (Battery/ HTTP) example, as the Sonnen API value is already correct (if the value is greater than 0 the battery is discharging, if greater than zero it is charging).