### PR TITLE
Discovergy meter user and password in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ If you want to contribute configurations to this repository please open a Pull R
 
 ```yaml
 - type: discovergy
-  user: demo@discovergy.com 
-  password: demo # password 
+  user: 'demo@discovergy.com' 
+  password: 'demo'  # password 
   meter: 1ESY1161229886
 ```
 

--- a/templates/meter-discovergy.go
+++ b/templates/meter-discovergy.go
@@ -9,8 +9,8 @@ func init() {
 		Class:  "meter",
 		Type:   "discovergy",
 		Name:   "Discovergy",
-		Sample: `user: demo@discovergy.com 
-password: demo # password 
+		Sample: `user: 'demo@discovergy.com' 
+password: 'demo'  # password 
 meter: 1ESY1161229886`,
 	}
 

--- a/yaml/meters/discovergy.yaml
+++ b/yaml/meters/discovergy.yaml
@@ -1,6 +1,6 @@
 type: discovergy
 name: Discovergy
 sample: |
-  user: demo@discovergy.com 
-  password: demo # password 
+  user: 'demo@discovergy.com' 
+  password: 'demo'  # password 
   meter: 1ESY1161229886


### PR DESCRIPTION
In case a Discovergy user created his login credentials (user/password) by using leading zeros or special characters (e.g. #) which ignored or interpreted as comments, quoting will assure that credential are treated completely as strings, without causing any discovergy api login issues. 

Refer to discussion https://github.com/andig/evcc/discussions/952